### PR TITLE
fix(component-compass): drop image.tag pin, let chart appVersion drive

### DIFF
--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -20,9 +20,6 @@ spec:
     securityContext:
       readOnlyRootFilesystem: false
 
-    image:
-      tag: main-738ec40
-
     serviceAccount:
       create: false
     ingress:


### PR DESCRIPTION
## Summary

- Removes the `image.tag: main-738ec40` override from `helmrelease.yaml`.
- Chart `0.1.3` (appVersion `0.1.2`) is published to GHCR with matching `component-compass-web-app:0.1.2` and `component-compass-web-app-migrator:0.1.2` images.
- The chart defaults `image.tag` to `.Chart.AppVersion`, so dropping the override lets Flux's `OCIRepository` semver range (`>=0.1.0 <1.0.0`) pick up new chart versions and pull the matching images automatically — no more per-release homelab PR.

Closes siggerzz/component-compass#201.

## Test plan

- [ ] After merge, watch Flux reconcile and confirm Deployment + migration Job pull `:0.1.2`.
- [ ] Confirm pod healthy and ingress responds at `compass.${SECRET_DOMAIN}`.
- [ ] Next chart release should roll out without a homelab PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment security configuration settings for the component-compass application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siggerzz/homelab/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->