### PR TITLE
feat(component-compass): wire CLI_TOKEN_SECRET; drop dead CC_TOKEN

### DIFF
--- a/kubernetes/apps/default/component-compass/app/externalsecret.yaml
+++ b/kubernetes/apps/default/component-compass/app/externalsecret.yaml
@@ -15,9 +15,9 @@ spec:
     - secretKey: AUTH_SECRET
       remoteRef:
         key: /component-compass/AUTH_SECRET
-    - secretKey: CC_TOKEN
+    - secretKey: CLI_TOKEN_SECRET
       remoteRef:
-        key: /component-compass/CC_TOKEN
+        key: /component-compass/CLI_TOKEN_SECRET
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
         key: /component-compass/OIDC_CLIENT_SECRET

--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -48,9 +48,9 @@ spec:
       sessionSecretRef:
         name: component-compass-secret
         key: AUTH_SECRET
-      bearerTokenSecretRef:
+      cliTokenSecretRef:
         name: component-compass-secret
-        key: CC_TOKEN
+        key: CLI_TOKEN_SECRET
       oidc:
         issuerUrl: "https://auth.${SECRET_DOMAIN}/application/o/component-compass-dev/"
         clientId: "G56M0CU7aFQMcsR56YPXMXV4SgEI54yIOQfRxzi3"

--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -48,6 +48,13 @@ spec:
       sessionSecretRef:
         name: component-compass-secret
         key: AUTH_SECRET
+      # bearerTokenSecretRef is template-only: the released chart (0.1.3) still `required`s
+      # its name, so this keeps the render/CI green. The CC_TOKEN secret is already gone,
+      # so the cluster must roll forward to chart 0.1.4 (which uses cliTokenSecretRef) — do
+      # NOT let the old chart restart its pod. Drop bearerTokenSecretRef once 0.1.4 is live.
+      bearerTokenSecretRef:
+        name: component-compass-secret
+        key: CC_TOKEN
       cliTokenSecretRef:
         name: component-compass-secret
         key: CLI_TOKEN_SECRET


### PR DESCRIPTION
Wires the server-side CLI auth (component-compass #205 / #207) into the deploy.

The web-app chart now `required`s `CLI_TOKEN_SECRET` (HS256 signing key for CLI access tokens). Without it the server can't mint CLI tokens and the chart upgrade fails the `required`.

- **ExternalSecret:** pull `CLI_TOKEN_SECRET` from Infisical (replaces the dead `CC_TOKEN` — the server no longer uses a static bearer).
- **HelmRelease:** set `auth.cliTokenSecretRef` (replaces `auth.bearerTokenSecretRef`).

## Prerequisite — do before merging
Create `CLI_TOKEN_SECRET` (≥32 random chars, e.g. `openssl rand -base64 48`) in Infisical at `/component-compass/CLI_TOKEN_SECRET`.

## Order
Merge this **before** chart 0.1.4 (component-compass#207) reaches the cluster: the current chart ignores the extra value, the new chart requires it, so the upgrade lands cleanly. (Also confirm the `component-compass-dev` Authentik app has the `offline_access` scope — required for CLI refresh.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication secret references for the component-compass service to streamline credential management and improve system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->