### PR TITLE
feat(component-compass): decouple deploy from chart version (image digest tracking)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -99,6 +99,18 @@
     },
     {
       description: [
+        'component-compass web-app: own app, deployed by tracking the main image digest (not chart releases). Pin the digest and check any time so a new main build rolls out promptly. Digest auto-merge is handled by the rule above.',
+      ],
+      matchPackageNames: [
+        'ghcr.io/siggerzz/component-compass-web-app',
+      ],
+      pinDigests: true,
+      schedule: [
+        'at any time',
+      ],
+    },
+    {
+      description: [
         'Group common infrastructure Helm charts',
       ],
       groupName: 'infrastructure-helm-charts',

--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -17,6 +17,17 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    # Deploy decoupled from the chart's appVersion: track the web-app image directly.
+    # Renovate digest-pins `tag` (see renovate.json5), so each new `main` build lands
+    # as a value change → rollout, independent of chart releases. The migrator is a
+    # distinct image; it rides the mutable `main` tag with Always so it re-pulls in
+    # sync with the runner each migration Job.
+    image:
+      repository: ghcr.io/siggerzz/component-compass-web-app
+      tag: main
+      migratorTag: main
+      pullPolicy: Always
+
     securityContext:
       readOnlyRootFilesystem: false
 


### PR DESCRIPTION
**DRAFT — do not merge until both:** (1) #272 (deploy-fix) is merged, and (2) component-compass chart **0.1.4** is released and live (the chart that wires `CLI_TOKEN_SECRET` into the pod env and adds `image.migratorTag` — component-compass#207).

## What this does
Decouples the web-app deploy from the chart version. Instead of a deploy requiring a chart release (which is changeset-gated, the gap that hid #205), the deploy tracks the image directly:

- Pins the **runner** image to `main`; Renovate digest-pins it (`renovate.json5`: `pinDigests` + `at any time`). The cluster's existing "auto-merge docker digest" rule then rolls each new `main` build out automatically.
- **migrator** rides `migratorTag: main` + `pullPolicy: Always`, so the migration Job re-pulls the matching build each upgrade. (Runner and migrator are distinct images → distinct digests, so they can't share one `tag@sha256:…` — hence the new `image.migratorTag` in the chart.)

After this, merging app code to component-compass `main` redeploys here on its own — no changeset, no chart bump. Chart releases go back to meaning "the chart changed."

## Why gated
- `image.migratorTag` only exists in chart 0.1.4+.
- The runner image (`main` = #205 code) needs the new chart's `CLI_TOKEN_SECRET` env wiring; deploying it under the current chart would run the auth server without its signing key.

## Heads-up
This makes every component-compass `main` merge auto-deploy (digest auto-merge is already on cluster-wide). If you'd rather review each deploy, exclude this image from the digest auto-merge rule.