### PR TITLE
chore(component-compass): drop dead bearerTokenSecretRef

### DIFF
--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -48,13 +48,6 @@ spec:
       sessionSecretRef:
         name: component-compass-secret
         key: AUTH_SECRET
-      # bearerTokenSecretRef is template-only: the released chart (0.1.3) still `required`s
-      # its name, so this keeps the render/CI green. The CC_TOKEN secret is already gone,
-      # so the cluster must roll forward to chart 0.1.4 (which uses cliTokenSecretRef) — do
-      # NOT let the old chart restart its pod. Drop bearerTokenSecretRef once 0.1.4 is live.
-      bearerTokenSecretRef:
-        name: component-compass-secret
-        key: CC_TOKEN
       cliTokenSecretRef:
         name: component-compass-secret
         key: CLI_TOKEN_SECRET


### PR DESCRIPTION
Final cleanup of the CLI-auth migration. The released chart (0.1.5) requires `cliTokenSecretRef` and no longer references `bearerTokenSecretRef` (`CC_TOKEN`), which was deleted from Infisical and dropped from the ExternalSecret. The ref was only kept transiently to keep the Flux-diff render green while the old chart (0.1.3) was still released.

Verified: `helm template` against the live chart `0.1.5` renders clean without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication secret configuration for improved security and authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->