### PR TITLE
feat(component-compass): track web-app image digest, decouple deploy from chart releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -99,6 +99,18 @@
     },
     {
       description: [
+        'component-compass web-app: own app, deployed by tracking the main image digest (not chart releases). Pin the digest and check any time so a new main build rolls out promptly. Digest auto-merge is handled by the rule above.',
+      ],
+      matchPackageNames: [
+        'ghcr.io/siggerzz/component-compass-web-app',
+      ],
+      pinDigests: true,
+      schedule: [
+        'at any time',
+      ],
+    },
+    {
+      description: [
         'Group common infrastructure Helm charts',
       ],
       groupName: 'infrastructure-helm-charts',

--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -17,6 +17,17 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    # Deploy decoupled from the chart's appVersion: track the web-app image directly.
+    # Renovate digest-pins `tag` (see renovate.json5), so each new `main` build lands
+    # as a value change → rollout, independent of chart releases. The migrator is a
+    # distinct image; it rides the mutable `main` tag with Always so it re-pulls in
+    # sync with the runner each migration Job.
+    image:
+      repository: ghcr.io/siggerzz/component-compass-web-app
+      tag: main
+      migratorTag: main
+      pullPolicy: Always
+
     securityContext:
       readOnlyRootFilesystem: false
 


### PR DESCRIPTION
## Why

The deploy-decouple intended by component-compass #208 (PR #273) is marked *merged* on GitHub but its commit never landed on `main` — `git merge-base --is-ancestor` confirms it's not an ancestor. `main` is currently running the older, *competing* approach from `a94d1f54` ("drop image.tag pin, let chart appVersion drive"), where `image.tag` defaults to `.Chart.AppVersion`. That re-gates deploy on a changeset (appVersion only bumps via one) — the exact #205 footgun #208 set out to remove.

## What

Restores the digest-tracking decouple on the HelmRelease:

- Pin the web-app `image.tag: main` (Renovate digest-pins `:main` → bumps the digest on every `main` build → Flux value change → rollout, independent of chart releases).
- `migratorTag: main` + `pullPolicy: Always` so the migrator re-pulls in sync with the runner each migration Job.
- Add the Renovate `pinDigests` rule for `ghcr.io/siggerzz/component-compass-web-app` (digest auto-merge already handled by the rule above it).

Chart releases now mean "the chart's structure changed" — still changeset-driven, because the chart is a published OCI artifact. The component-compass chart (0.1.5, #207) already supports this; `values.yaml` documents digest-pinning and added `migratorTag`.

## Validation

- `helm template` against chart `0.1.5` → runner `ghcr.io/siggerzz/component-compass-web-app:main`, migrator `...-migrator:main`, both `pullPolicy: Always`.
- `renovate-config-validator` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration for container images.
  * Updated web application image versioning and pull policies in deployment configuration to ensure consistent image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->