### PR TITLE
fix(renovate): slash-wrap managerFilePatterns regexes so kubernetes/** managers match

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,32 +24,32 @@
   ],
   flux: {
     managerFilePatterns: [
-      '(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$',
+      '/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/',
     ],
   },
   'helm-values': {
     managerFilePatterns: [
-      '(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$',
+      '/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/',
     ],
   },
   helmfile: {
     managerFilePatterns: [
-      '(^|/)helmfile\\.ya?ml(?:\\.j2)?$',
+      '/(^|/)helmfile\\.ya?ml(?:\\.j2)?$/',
     ],
   },
   kubernetes: {
     managerFilePatterns: [
-      '(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$',
+      '/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/',
     ],
   },
   kustomize: {
     managerFilePatterns: [
-      '(^|/)kustomization\\.ya?ml(?:\\.j2)?$',
+      '/(^|/)kustomization\\.ya?ml(?:\\.j2)?$/',
     ],
   },
   pip_requirements: {
     managerFilePatterns: [
-      '(^|/)[\\w-]*requirements(-\\w+)?\\.(txt|pip)(?:\\.j2)?$',
+      '/(^|/)[\\w-]*requirements(-\\w+)?\\.(txt|pip)(?:\\.j2)?$/',
     ],
   },
   packageRules: [
@@ -400,7 +400,7 @@
         'Process YAML custom dependencies',
       ],
       managerFilePatterns: [
-        '(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$',
+        '/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/',
       ],
       matchStrings: [
         'datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( repository=(?<registryUrl>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)',


### PR DESCRIPTION
## Symptom

Renovate stopped opening Helm chart and in-cluster image update PRs **since 2026-01-25** (last chart PR: #247, loki). github-release/aqua updates kept flowing, which masked it. The Dependency Dashboard's `Detected Dependencies` listed only `github-actions`, `helmfile`, `kustomize`, `mise`, `pip_requirements` — **no `flux`, `kubernetes`, or `helm-values`** — despite 53 `HelmRelease` files in the repo.

## Root cause

PR #255 ("migrate Renovate config") renamed `fileMatch` → `managerFilePatterns` but left the values as **bare regex strings**:

```json5
flux: { managerFilePatterns: ['(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$'] }
```

`managerFilePatterns` only treats a string as a **regex** when it's wrapped in slashes (`/…/`); otherwise it's a **minimatch glob**. That regex is meaningless as a glob, so it matched nothing. `flux`, `helm-values` and `kubernetes` depend on this `kubernetes/**` override (their built-in defaults are `gotk-components.yaml` / `values.yaml` / none), so they went dark. `helmfile`, `kustomize`, `pip_requirements`, `github-actions`, `mise` kept working on their defaults — which is exactly the dashboard's list.

Renovate's own debug log shows it:
```
Using file pattern: /(?:^|/)gotk-components\.ya?ml$/ for manager flux   ← default (slashes = regex)
Using file pattern: (^|/)kubernetes/.+\.ya?ml(?:\.j2)?$ for manager flux ← our override (no slashes = glob → 0 matches)
```

## Fix

Slash-wrap each override regex (7 patterns: flux, helm-values, helmfile, kubernetes, kustomize, pip_requirements, customManagers). Overrides are *additive* to defaults, so the managers that currently survive on defaults are unaffected.

## Verification — `renovate --platform=local --dry-run`

| manager | matched files (before → after) |
|---|---|
| flux | **0 → 287** |
| helm-values | **0 → 287** |
| kubernetes | **0 → 287** |
| regex (customManagers) | **0 → 287** |
| helmfile / kustomize / github-actions / mise / pip | unchanged |

Extraction now sees `authentik`, `cilium`, `coredns`, `traefik`, `kube-prometheus-stack`, `app-template`, … and `ghcr.io/siggerzz/component-compass-web-app` — so the #275 / #208 digest-pin decouple finally has a Renovate that scans the file. `renovate-config-validator` passes.

## Heads-up

~4 months of chart/image updates will surface on the next scheduled run (`every weekend`); `prConcurrentLimit: 10` + `minimumReleaseAge: 3 days` throttle the backlog, and the patch/digest auto-merge rules will clear the safe ones.