### PR TITLE
fix(renovate): deploy component-compass web-app promptly (auto-merge pinDigest, skip release-age soak)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,7 +84,7 @@
     },
     {
       description: [
-        'Auto-merge safe Docker image patch and digest updates',
+        'Auto-merge safe Docker image patch, digest, and initial digest-pin updates',
       ],
       matchDatasources: [
         'docker',
@@ -92,6 +92,7 @@
       matchUpdateTypes: [
         'patch',
         'digest',
+        'pinDigest',
       ],
       automerge: true,
       automergeType: 'branch',
@@ -99,12 +100,13 @@
     },
     {
       description: [
-        'component-compass web-app: own app, deployed by tracking the main image digest (not chart releases). Pin the digest and check any time so a new main build rolls out promptly. Digest auto-merge is handled by the rule above.',
+        'component-compass web-app: own app, deployed by tracking the main image digest (not chart releases). Pin the digest and check any time so a new main build rolls out promptly; the (pin)digest auto-merge is handled by the rule above. minimumReleaseAge is 0 here: `main` is a mutable tag we build ourselves, and the global 3-day soak would perpetually reset against fresh builds and stall the deploy.',
       ],
       matchPackageNames: [
         'ghcr.io/siggerzz/component-compass-web-app',
       ],
       pinDigests: true,
+      minimumReleaseAge: '0 days',
       schedule: [
         'at any time',
       ],


### PR DESCRIPTION
Follow-up to #275/#276 so the digest-pin decouple actually auto-deploys (surfaced by #277 sitting un-mergeable).

## Two changes

1. **Add `pinDigest` to the docker auto-merge rule.** The *first* pin of a tag is updateType `pinDigest`, not `digest` — so it was excluded from auto-merge and needed a manual merge (that's why #277 says "merge manually"). Subsequent digest *bumps* already auto-merged.

2. **`minimumReleaseAge: '0 days'` on the web-app image.** `main` is a mutable tag we build ourselves. The global `3 days` soak measures the *digest's* creation age, which resets on every push — so for an actively-developed app the latest digest is perpetually <3 days old and the deploy would **stall indefinitely** (this is exactly the `renovate/stability-days` pending check on #277). The soak exists to vet third-party releases; it adds nothing for our own CI-built image.

## Effect

A new `main` build → Renovate pins/bumps its digest → auto-merges immediately (no 3-day wait, no manual step) → Flux rolls out. Fully hands-off, which is the point of #208.

## Verification

`renovate-config-validator` passes.

## Note on #277

#277 (the initial pin) can be merged by hand now; or once this lands, Renovate re-evaluates it on the next run with the soak lifted + `pinDigest` auto-merge and clears it on its own.