### PR TITLE
fix(component-compass): digest-pin migrator in lockstep with runner

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,10 +100,11 @@
     },
     {
       description: [
-        'component-compass web-app: own app, deployed by tracking the main image digest (not chart releases). Pin the digest and check any time so a new main build rolls out promptly; the (pin)digest auto-merge is handled by the rule above. minimumReleaseAge is 0 here: `main` is a mutable tag we build ourselves, and the global 3-day soak would perpetually reset against fresh builds and stall the deploy.',
+        'component-compass web-app + migrator: our own app, deployed by tracking the main image digests (not chart releases). Pin BOTH the runner and migrator digests so they bump in lockstep — a floating migrator tag skewed against the pinned runner and ran a stale migrator, silently skipping a new migration. Check any time so a new main build rolls out promptly; the (pin)digest auto-merge is handled by the rule above. minimumReleaseAge is 0 here: `main` is a mutable tag we build ourselves, and the global 3-day soak would perpetually reset against fresh builds and stall the deploy.',
       ],
       matchPackageNames: [
         'ghcr.io/siggerzz/component-compass-web-app',
+        'ghcr.io/siggerzz/component-compass-web-app-migrator',
       ],
       pinDigests: true,
       minimumReleaseAge: '0 days',

--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -17,15 +17,16 @@ spec:
       strategy: rollback
       retries: 3
   values:
-    # Deploy decoupled from the chart's appVersion: track the web-app image directly.
-    # Renovate digest-pins `tag` (see renovate.json5), so each new `main` build lands
-    # as a value change → rollout, independent of chart releases. The migrator is a
-    # distinct image; it rides the mutable `main` tag with Always so it re-pulls in
-    # sync with the runner each migration Job.
+    # Deploy decoupled from the chart's appVersion: track the web-app images directly.
+    # Renovate digest-pins BOTH `tag` (runner) and `migratorTag` (migrator) — see
+    # renovate.json5 — so each new `main` build lands as a value change → rollout.
+    # Pin both in lockstep: a floating `main` migratorTag previously skewed against the
+    # digest-pinned runner and ran a stale migrator, so a new migration (the `tags`
+    # table) silently never applied. Keep both as `main@sha256:…` digests.
     image:
       repository: ghcr.io/siggerzz/component-compass-web-app
       tag: main@sha256:0e522c771028e34d6bc3e93cf0b2cb210672f297d1435a862b6b978fb7d1bc20
-      migratorTag: main
+      migratorTag: main@sha256:aa949e244bd1aab024ce479b474a54d98fc217e3224edc055f8d27ec781499ca
       pullPolicy: Always
 
     securityContext:


### PR DESCRIPTION
## Problem
After deploying 0.1.5, `/packages` 500s with `relation "tags" does not exist`. The new app is running but the `tags` table was never created.

## Root cause
The runner is Renovate digest-pinned, but the migrator rode the floating `:main` tag (`migratorTag: main`). On the last deploy the migration Job pulled a **stale** migrator (`sha256:33461329…`, predates the `0003` tags migration) instead of the current build (`sha256:aa949e244…`). drizzle applied 0000–0002 (already present), reported success, and never created `tags` — runner/migrator skew.

## Fix
- Pin `migratorTag` to `main@sha256:aa949e244…` (the build that has 0003) — matching the runner's digest-pin pattern.
- Add `component-compass-web-app-migrator` to the Renovate digest-pin rule so both images bump in lockstep going forward.

Merging triggers a Helm upgrade → the migration hook re-runs with the correct migrator → `tags` is created → `/packages` recovers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image pinning rules to apply to both app and migrator images.
  * Updated deployment configuration to use pinned migrator image digest instead of floating tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->