### PR TITLE
feat(component-compass): external ingress + COMPASS_CI_UPLOAD_TOKEN secret for CI uploads

### DIFF
--- a/kubernetes/apps/default/component-compass/app/externalsecret.yaml
+++ b/kubernetes/apps/default/component-compass/app/externalsecret.yaml
@@ -18,6 +18,9 @@ spec:
     - secretKey: CLI_TOKEN_SECRET
       remoteRef:
         key: /component-compass/CLI_TOKEN_SECRET
+    - secretKey: COMPASS_CI_UPLOAD_TOKEN
+      remoteRef:
+        key: /component-compass/COMPASS_CI_UPLOAD_TOKEN
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
         key: /component-compass/OIDC_CLIENT_SECRET

--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -36,8 +36,9 @@ spec:
       create: false
     ingress:
       enabled: true
-      className: internal
+      className: external
       annotations:
+        external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
         gatus.home-operations.com/enabled: "true"
         gatus.home-operations.com/endpoint: |
           ui:


### PR DESCRIPTION
Deploy prep so GitHub-hosted CI runners can push scan artifacts to the web-app. Pairs with siggerzz/component-compass#231 (the CLI/server code).

Two changes:

1. **Sync `COMPASS_CI_UPLOAD_TOKEN`** via the `component-compass-secret` ExternalSecret. The deployment mounts this secret via `envFrom`, so the new key is exposed as an env var with no chart change.
2. **Expose the web-app via external ingress** — `className: internal` → `external` plus `external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}`, so `compass.${SECRET_DOMAIN}` resolves and is reachable from the public internet (CI runners).

## Merge gate
- [x] Infisical key `/component-compass/COMPASS_CI_UPLOAD_TOKEN` exists first.

If the ExternalSecret mapping is applied before the Infisical key exists, the reconcile errors and won't pick up the new key (existing keys are retained — no outage).

## After merge
- ESO syncs within `refreshInterval` (5m); `envFrom` is injected at pod start, so restart the web-app to pick up the new var: `kubectl rollout restart deploy/component-compass-web-app -n default` (or `flux reconcile`).
- external-dns publishes the public record for `compass.${SECRET_DOMAIN}`; allow for DNS propagation before CI can reach it.
