### PR TITLE
fix(component-compass): renovate-track migratorTag + re-pin migrator (fixes prod is_primary error)

### DIFF
--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -26,7 +26,8 @@ spec:
     image:
       repository: ghcr.io/siggerzz/component-compass-web-app
       tag: main@sha256:f61403d6a9a7c0827fc158f4317d6ce7f33c9ea0596b9d96d1e91efaea03684d
-      migratorTag: main@sha256:aa949e244bd1aab024ce479b474a54d98fc217e3224edc055f8d27ec781499ca
+      # renovate: datasource=docker depName=ghcr.io/siggerzz/component-compass-web-app-migrator
+      migratorTag: main@sha256:f846388adda0a7dcc53cf0482c0d986f709d555ec8fdb81a8664c0882fc4119c
       pullPolicy: Always
 
     securityContext:


### PR DESCRIPTION
## Why

The web-app is 500ing on every tag-loading page: `column "is_primary" does not exist`. Migration `0004` (`ALTER TABLE tags ADD COLUMN is_primary`) never applied in prod because the migrate job ran a **stale migrator image** (`aa949e`, pre-`0004`).

Root cause — #279 didn't actually work: it pinned `migratorTag` as a digest and added a renovate `packageRule` for the migrator package, but a packageRule only acts on dependencies a *manager detects*. The runner (`image.tag`) is auto-detected by renovate's built-in helm-values manager and bumped every build; `migratorTag` is a non-standard key the built-in manager ignores, and it had **no `# renovate:` annotation** for the repo's customManager to pick up. So renovate bumped the runner four times (`…→f61403d`) and left `migratorTag` frozen at `aa949e`. Lockstep declared, never enforced.

## Change

- **Permanent:** add `# renovate: datasource=docker depName=…/component-compass-web-app-migrator` above `migratorTag` so the customManager tracks it and the existing packageRule pins its digest — genuine lockstep going forward.
- **Recovery:** re-pin `migratorTag` to the current migrator digest (`f846388`), which contains `0004`. Latest `main` migrations are `0000-0004` (no newer migration), so this matches what the deployed runner expects.

On merge → Flux upgrade → the migrate job re-runs the `f846388` migrator → applies `0004` → `tags.is_primary` exists → web-app recovers.

## Verification
- helmrelease.yaml parses; diff is the annotation + the digit change only.
- Post-merge: confirm the new `migrate-N` job Completes and the web-app logs stop showing `is_primary` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with the latest component versions to maintain system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->