### PR TITLE
fix(component-compass): raise web-app memory to 1Gi (fix SSR OOM crashloop)

### DIFF
--- a/kubernetes/apps/default/component-compass/app/helmrelease.yaml
+++ b/kubernetes/apps/default/component-compass/app/helmrelease.yaml
@@ -30,6 +30,16 @@ spec:
       migratorTag: main@sha256:f846388adda0a7dcc53cf0482c0d986f709d555ec8fdb81a8664c0882fc4119c
       pullPolicy: Always
 
+    # Chart default (512Mi limit) OOM-killed the SSR process — V8 heap died at
+    # ~254MB rendering tag/component pages over the grown dataset. Bump so the
+    # cgroup-aware Node heap has headroom.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
     securityContext:
       readOnlyRootFilesystem: false
 


### PR DESCRIPTION
## Why

After the `is_primary` migration fix (#281) let tag-dependent pages render again, the web-app started crash-looping with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` (exit 139, 2 restarts). The chart default caps the runner at `512Mi`, and V8's heap died at ~254MB SSR-ing component/tag tables over the now-larger dataset (pie-aperture ×4 apps + cal.diy).

## Change

Override `resources` for the runner: request `512Mi`, limit `1Gi`. Node is cgroup-aware, so the larger container raises the default heap ceiling — no `NODE_OPTIONS` needed.

## Verify
- helmrelease parses; only a `resources:` block added.
- Post-merge: web-app pod stops restarting; no more heap-limit FATALs.

If it OOMs again at 1Gi, that points to an unbounded query (e.g. a cross-repo view loading everything) — a component-compass-side profiling follow-up, tracked separately.