### PR TITLE
fix(renovate): exempt component-compass CD from the concurrent-PR limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,14 +100,17 @@
     },
     {
       description: [
-        'component-compass web-app + migrator: our own app, deployed by tracking the main image digests (not chart releases). Pin BOTH the runner and migrator digests so they bump in lockstep — a floating migrator tag skewed against the pinned runner and ran a stale migrator, silently skipping a new migration. Check any time so a new main build rolls out promptly; the (pin)digest auto-merge is handled by the rule above. minimumReleaseAge is 0 here: `main` is a mutable tag we build ourselves, and the global 3-day soak would perpetually reset against fresh builds and stall the deploy.',
+        'component-compass web-app + migrator: our own app, deployed by tracking the main image digests (not chart releases). Pin BOTH the runner and migrator digests so they bump in lockstep — a floating migrator tag skewed against the pinned runner and ran a stale migrator, silently skipping a new migration. Check any time so a new main build rolls out promptly; the (pin)digest auto-merge is handled by the rule above. `groupName` puts the runner + migrator in ONE branch so they land as a single auto-merged commit, not two ~1-min-apart commits — closes the sub-minute window where main carried a bumped runner ahead of a still-stale migrator. minimumReleaseAge is 0 here: `main` is a mutable tag we build ourselves, and the global 3-day soak would perpetually reset against fresh builds and stall the deploy. prConcurrentLimit/branchConcurrentLimit are 0 (unlimited) so this CD path never queues behind unrelated dependency PRs: the global concurrent limit (10) was once fully held by stale major-version PRs, so a fresh main build sat rate-limited on the dashboard instead of deploying.',
       ],
       matchPackageNames: [
         'ghcr.io/siggerzz/component-compass-web-app',
         'ghcr.io/siggerzz/component-compass-web-app-migrator',
       ],
+      groupName: 'component-compass',
       pinDigests: true,
       minimumReleaseAge: '0 days',
+      prConcurrentLimit: 0,
+      branchConcurrentLimit: 0,
       schedule: [
         'at any time',
       ],


### PR DESCRIPTION
## Symptom

The query-bar search build (component-compass #244) shipped a new `main` web-app image (`b45e7fb → 3c3fa2e`) but never deployed — no `chore(container): update …component-compass-web-app` commit landed on `main`.

## Root cause

Renovate **detected** the update correctly; it's queued under **"Rate-Limited"** on the dependency dashboard (#37). The cause is concurrency, not config:

- `prConcurrentLimit: 10` is set globally, and `branchConcurrentLimit` defaults to it.
- All 10 slots are permanently held by long-stale major-version PRs (cloudflared, talos, helm 4, checkout v6, python 3.14…).
- The component-compass deploy auto-merges via *branch*, which counts against `branchConcurrentLimit` — so it can't even create its branch while the limit is saturated.
- `:disableRateLimiting` only zeroes `prHourlyLimit`; it does not touch the concurrent limit.

It worked before because the open-PR count only just crept to 10 (cloudflared PR #283 opened ~3.5h before the image landed).

## Fix

Set `prConcurrentLimit: 0` + `branchConcurrentLimit: 0` on the component-compass packageRule so our own CD path is never starved by unrelated dependency PRs. Also adds `groupName: 'component-compass'` so the runner + migrator land as one lockstep commit.

This is consistent with the rule's existing intent (it already overrides `schedule` + `minimumReleaseAge` so builds roll out promptly).

## Verification

- `renovate-config-validator` passes.
- After merge, the next Renovate run creates + auto-merges the lockstep bump (web-app `b45e7fb → 3c3fa2e`, migrator `b2ef198 → 7a4a0b3`) and Flux deploys.

## Note (separate hygiene, not in this PR)

Those 10 zombie PRs are starving *all* updates, not just compass (~25 others sit rate-limited behind them). Worth triaging (merge or `ignore`) so the limit reflects real in-flight work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized automation configuration for dependency management to enhance concurrency handling in deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->